### PR TITLE
Overode destroy method to clean up components

### DIFF
--- a/src/Multiselect.js
+++ b/src/Multiselect.js
@@ -162,7 +162,7 @@ Ext.define('Ux.field.Multiselect', {
             value = me.convertValue(newValue,me.getValueField(),me.getDisplayField());
             
       value = value.join(me.getDelimiter());
-      me.superclass.superclass.updateValue.call(me,[value]);
+      me.superclass.superclass.superclass.updateValue.call(me,[value]);
     },
 
     /**

--- a/src/Multiselect.js
+++ b/src/Multiselect.js
@@ -43,6 +43,29 @@ Ext.define('Ux.field.Multiselect', {
 
         return Ext.factory(config, 'Ext.Button', this.getDoneButton());
     },
+	
+	/**
+     * Override destroy to make sure all components are cleaned up on destroy
+     */
+    destroy: function(){
+	    if(this.getDoneButton()){
+	        this.getDoneButton().destroy();
+	    }
+    
+	    if(this.getClearButton()){
+	        this.getClearButton().destroy();
+	    }
+    
+	    if(this.getClearButton()){
+	        this.getClearButton().destroy();
+	    }
+    
+	    if(this.listPanel){
+	        this.listPanel.destroy();
+	    }
+    
+	    this.callParent(arguments);
+	},
 
     applyClearButton: function(config) {
         if (config) {

--- a/src/Multiselect.js
+++ b/src/Multiselect.js
@@ -185,7 +185,7 @@ Ext.define('Ux.field.Multiselect', {
             value = me.convertValue(newValue,me.getValueField(),me.getDisplayField());
             
       value = value.join(me.getDelimiter());
-      me.superclass.superclass.superclass.updateValue.call(me,[value]);
+      me.superclass.superclass.updateValue.call(me,[value]);
     },
 
     /**


### PR DESCRIPTION
I was checking out the Component Manager before and after showing this MultiSelect and noticed it was leaving around some components on destroy.  I overrode the destroy method to clean things up.

thanks,

Russell
